### PR TITLE
Clarify build id getter test cases

### DIFF
--- a/build_id_getter_test.go
+++ b/build_id_getter_test.go
@@ -41,7 +41,7 @@ func Test_GetBuildIDs_without_wildcards(t *testing.T) {
 			Workflows: []model.Workflow{
 				{
 					Name:       "workflow1_1",
-					ExternalId: "build1_1",
+					ExternalId: "build3",
 				},
 			},
 		},
@@ -71,23 +71,23 @@ func Test_GetBuildIDs_without_wildcards(t *testing.T) {
 		},
 		{
 			desc:                 "when user defines targets and the result has common subset, it filters the duplications",
-			targetNames:          []string{"stage1*", "*workflow1"},
+			targetNames:          []string{"stage1*", "*workflow1_1"},
 			finishedStages:       finishedStages,
-			expectedBuildIDs:     []string{"build1_1", "build1_2a", "build1_2b"},
+			expectedBuildIDs:     []string{"build1_1", "build1_2a", "build1_2b", "build3"},
 			expectedErrorMessage: "",
 		},
 		{
 			desc:                 "when user defines workflow names, it return the build IDs",
 			targetNames:          []string{"*workflow1_1", "*workflow2"},
 			finishedStages:       finishedStages,
-			expectedBuildIDs:     []string{"build1_1", "build2"},
+			expectedBuildIDs:     []string{"build1_1", "build3", "build2"},
 			expectedErrorMessage: "",
 		},
 		{
 			desc:                 "when user wants to query all generated artifacts",
 			targetNames:          []string{"*"},
 			finishedStages:       finishedStages,
-			expectedBuildIDs:     []string{"build1_1", "build1_2a", "build1_2b", "build2", "build4"},
+			expectedBuildIDs:     []string{"build1_1", "build1_2a", "build1_2b", "build2", "build3", "build4"},
 			expectedErrorMessage: "",
 		},
 		{
@@ -101,7 +101,7 @@ func Test_GetBuildIDs_without_wildcards(t *testing.T) {
 			desc:                 "when user does not define target names, it returns with all build ids",
 			targetNames:          []string{},
 			finishedStages:       finishedStages,
-			expectedBuildIDs:     []string{"build1_1", "build1_2a", "build1_2b", "build2", "build4"},
+			expectedBuildIDs:     []string{"build1_1", "build1_2a", "build1_2b", "build2", "build3", "build4"},
 			expectedErrorMessage: "",
 		},
 		{


### PR DESCRIPTION
External build ids should always be unique, this adds more confidence in the tests (as we're sure it finds the build id in stage3 too).

<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
