### PR TITLE
[PLANG-1590] Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use the `artifact_sources` input variable to limit the downloads to a set of sta
 - `stage1.workflow1` - Gets the artifacts from the stage1's workflow1.
 - `stage1.*` - Gets all artifacts from the stage1's workflows.
 - `*workflow1` - Gets the workflows' artifacts from all stages.
-- `*` - Gets every generated artifacts in the pipeline.
+- `.*` - Gets every generated artifacts in the pipeline.
 
 ##### Wildcard based artifact pull
 


### PR DESCRIPTION
Using all artifact sources in the documentation is wrongly stated as usable by a simple '*' character. It can be used by '.*'.

<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
